### PR TITLE
Add template flag

### DIFF
--- a/__tests__/download.spec.js
+++ b/__tests__/download.spec.js
@@ -67,22 +67,26 @@ describe("unzip", () => {
     }));
     const child_process = require("child_process");
     const download = require("../lib/download");
-    download.unzip("filepath", { outputDirectoryPath: "my-app" }, () => {
-      try {
-        expect(child_process.exec).toHaveBeenCalledWith(
-          `tar -x -f filepath -C my-app${
-            process.platform === "linux" ? " --wildcards" : ""
-          } --exclude .github --strip=3 */examples/main`,
-          {
-            cwd: process.cwd(),
-          },
-          expect.any(Function),
-        );
-        done();
-      } catch (err) {
-        done(err);
-      }
-    });
+    download.unzip(
+      "filepath",
+      { outputDirectoryPath: "my-app", sourcePath: "examples/main" },
+      () => {
+        try {
+          expect(child_process.exec).toHaveBeenCalledWith(
+            `tar -x -f filepath -C my-app${
+              process.platform === "linux" ? " --wildcards" : ""
+            } --exclude .github --strip=3 */examples/main`,
+            {
+              cwd: process.cwd(),
+            },
+            expect.any(Function),
+          );
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+    );
   });
 
   it("should ignore the .github folder", (done) => {
@@ -94,16 +98,20 @@ describe("unzip", () => {
     const zippath = path.resolve(__dirname, "fixtures", "output.tar.gz");
     const targetDirectoryPath = path.resolve(__dirname, "fixtures", "output");
 
-    download.unzip(zippath, { outputDirectoryPath: targetDirectoryPath }, (err) => {
-      try {
-        expect(err).toBeNull();
-        fs.readdir(targetDirectoryPath, (err, files) => {
-          expect(files).not.toContain(".github");
-          done();
-        });
-      } catch (err) {
-        done(err);
-      }
-    });
+    download.unzip(
+      zippath,
+      { outputDirectoryPath: targetDirectoryPath, sourcePath: "examples/main" },
+      (err) => {
+        try {
+          expect(err).toBeNull();
+          fs.readdir(targetDirectoryPath, (err, files) => {
+            expect(files).not.toContain(".github");
+            done();
+          });
+        } catch (err) {
+          done(err);
+        }
+      },
+    );
   });
 });

--- a/__tests__/template.spec.js
+++ b/__tests__/template.spec.js
@@ -1,0 +1,14 @@
+const path = require("path");
+const { getTemplatePath } = require("../lib/template");
+
+describe("getTemplatePath", () => {
+  it("should return the directory and target", () => {
+    const directoryPath = path.join("templates", "foo");
+    const result = getTemplatePath(directoryPath);
+    expect(result).toEqual(["templates", "foo"]);
+  });
+
+  it("should throw an error if the path is invalid", () => {
+    expect(() => getTemplatePath("foo")).toThrow();
+  });
+});

--- a/index.js
+++ b/index.js
@@ -143,7 +143,6 @@ program.parse(process.argv);
 
 function isValidSourcePath(templatePath) {
   const [directory, template] = templatePath.split(path.sep);
-  console.log({ directory, template });
   if (directory !== "examples" && directory !== "templates") {
     return false;
   }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ program
   .version("0.1.2");
 
 // program options
-program.argument("<projectDirectoryPath>").option("-r --region <string>", "specified region");
+program
+  .argument("<projectDirectoryPath>")
+  .option("--template <string>", "specified template", path.join("examples", "main"));
 
 program.action((projectDirectoryPath) => {
   scaffoldRadFishApp(projectDirectoryPath);
@@ -80,13 +82,22 @@ async function scaffoldRadFishApp(projectDirectoryPath) {
         });
       });
 
+      const sourcePath = program.opts().template;
+      if (!isValidSourcePath(sourcePath)) {
+        throw new Error(`Invalid template path: ${sourcePath}`);
+      }
+
       await new Promise((resolve, reject) => {
-        unzip(tarballFilePath, { outputDirectoryPath: targetDirectoryPath }, (err, res) => {
-          if (err) {
-            return reject(err);
-          }
-          resolve(res);
-        });
+        unzip(
+          tarballFilePath,
+          { outputDirectoryPath: targetDirectoryPath, sourcePath: sourcePath },
+          (err, res) => {
+            if (err) {
+              return reject(err);
+            }
+            resolve(res);
+          },
+        );
       });
 
       console.log(`Project successfully created.`);
@@ -129,3 +140,36 @@ async function scaffoldRadFishApp(projectDirectoryPath) {
 
 // this needs to be called after all other program commands...
 program.parse(process.argv);
+
+function isValidSourcePath(templatePath) {
+  const [directory, template] = templatePath.split(path.sep);
+  console.log({ directory, template });
+  if (directory !== "examples" && directory !== "templates") {
+    return false;
+  }
+
+  if (directory === "examples") {
+    switch (template) {
+      case "computed-fields":
+      case "dynamic-form":
+      case "field-validators":
+      case "main":
+      case "multistep-form":
+      case "network-status":
+      case "on-device-storage":
+      case "simple-form":
+      case "simple-table":
+        return true;
+      default:
+        return false;
+    }
+  }
+  if (directory === "templates") {
+    switch (template) {
+      case "react-javascript":
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/lib/download.js
+++ b/lib/download.js
@@ -2,6 +2,7 @@ const child_process = require("child_process");
 const fs = require("fs");
 const https = require("https");
 const path = require("path");
+const { getTemplatePath } = require("./template");
 
 /**
  *
@@ -63,9 +64,9 @@ module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
     untarCommand += " --wildcards";
   }
 
-  const targetProjectDirectory = path.join("examples", "main");
+  const sourcePath = getTemplatePath(options.sourcePath || "");
 
-  const includePattern = path.join("*", targetProjectDirectory);
+  const includePattern = path.join("*", sourcePath.join(path.sep));
 
   const pathDepth = includePattern.split(path.sep).length;
   untarCommand += ` --exclude .github --strip=${pathDepth} ${includePattern}`;

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,0 +1,16 @@
+const path = require("path");
+
+module.exports.getTemplatePath = (directoryPath) => {
+  const parts = directoryPath.split(path.sep);
+  let [directory, target] = parts;
+  if (
+    !directory ||
+    !target ||
+    parts.length !== 2 ||
+    (directory !== "templates" && directory !== "examples")
+  ) {
+    throw new Error(`Invalid repository path: ${directoryPath}`);
+  }
+
+  return [directory, target];
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nmfs-radfish/create-radfish-app",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A cli tool for bootstrapping a radfish app",
   "bin": {
     "create-radfish-app": "./index.js"


### PR DESCRIPTION
Adds a `--template` flag that should match one of the directories in the boilerplate repository.

**Usage**
Create and run a project using the simple form example.
```
npx @nmfs-radfish/create-radfish-app my-app --template examples/simple-form
```