### PR TITLE
Bump node engine version to 20+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "29.7.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@nmfs-radfish/create-radfish-app",
   "version": "0.2.1",
   "description": "A cli tool for bootstrapping a radfish app",
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "create-radfish-app": "./index.js"
   },


### PR DESCRIPTION
Update node engine requirement. This should warn users to use Node v20+ while using the CLI.