### PR TITLE
RADFISH-253 Test RADFish on Windows 10 and Edge browser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,6 @@
     "prettier"
   ],
   "rules": {
-    "prettier/prettier": ["error", { "endOfLine": "auto" }]
+    "prettier/prettier": "error"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,6 @@
     "prettier"
   ],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": ["error", { "endOfLine": "auto" }]
   }
 }

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,15 +7,20 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node-version: ["18"]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: "18"
+          node-version: ${{ matrix.node-version }}
 
       - name: Install build dependencies
         run: npm install

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,5 @@
   "printWidth": 100,
   "singleQuote": false,
   "trailingComma": "all",
-  "bracketSpacing": true, 
-   "endOfLine": "auto"
+  "bracketSpacing": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "printWidth": 100,
   "singleQuote": false,
   "trailingComma": "all",
-  "bracketSpacing": true
+  "bracketSpacing": true, 
+  "endOfLine": "auto"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "printWidth": 100,
   "singleQuote": false,
   "trailingComma": "all",
-  "bracketSpacing": true
+  "bracketSpacing": true, 
+   "endOfLine": "auto"
 }

--- a/__tests__/download.spec.js
+++ b/__tests__/download.spec.js
@@ -30,7 +30,9 @@ describe("downloadFile", () => {
 
     download.downloadFile("https://example.com", "download/path", (err, res) => {
       try {
-        expect(fs.createWriteStream).toHaveBeenCalledWith(expect.stringMatching("download/path"));
+        const expectedPath = path.join("download", "path");
+        const receivedPath = expect.stringMatching(new RegExp(`${expectedPath.replace(/\\/g, '\\\\')}$`));
+        expect(fs.createWriteStream).toHaveBeenCalledWith(receivedPath);
         expect(https.get).toHaveBeenCalledWith(
           {
             hostname: "example.com",

--- a/lib/download.js
+++ b/lib/download.js
@@ -94,7 +94,7 @@ module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
     }
 
     await fs.promises.mkdir(outputDir, { recursive: true });
-    await moveDirectoryContents(sourcePathInTemp, outputDir);
+    await fs.promises.cp(sourcePathInTemp, outputDir, { recursive: true });
 
     // Clean up temp directory
     await fs.promises.rmdir(tempDir, { recursive: true });
@@ -104,23 +104,3 @@ module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
     callback(err, `Error during unzip and move: ${err.message}`);
   }
 };
-
-async function moveDirectoryContents(srcDir, destDir) {
-  // Ensure the destination directory exists
-  await fs.promises.mkdir(destDir, { recursive: true });
-
-  // Move each file or directory
-  const items = await fs.promises.readdir(srcDir, { withFileTypes: true });
-  for (const item of items) {
-    const srcItemPath = path.join(srcDir, item.name);
-    const destItemPath = path.join(destDir, item.name);
-
-    if (item.isDirectory()) {
-      await fs.promises.mkdir(destItemPath, { recursive: true });
-      await moveDirectoryContents(srcItemPath, destItemPath);
-    } else {
-      await fs.promises.copyFile(srcItemPath, destItemPath);
-      await fs.promises.unlink(srcItemPath);
-    }
-  }
-}

--- a/lib/download.js
+++ b/lib/download.js
@@ -66,9 +66,9 @@ module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
 
   const sourcePath = getTemplatePath(options.sourcePath || "");
 
-  const includePattern = path.join("*", sourcePath.join(path.sep));
+  const includePattern = `*/${sourcePath.join("/")}`;
 
-  const pathDepth = includePattern.split(path.sep).length;
+  const pathDepth = sourcePath.length + 1;
   untarCommand += ` --exclude .github --strip=${pathDepth} ${includePattern}`;
 
   child_process.exec(untarCommand, { cwd: filepathDir }, (err, stdout, stderr) => {

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,8 +1,10 @@
-const child_process = require("child_process");
 const fs = require("fs");
 const https = require("https");
 const path = require("path");
-const { getTemplatePath } = require("./template");
+const { exec } = require("child_process");
+const { promisify } = require("util");
+
+const execAsync = promisify(exec);
 
 /**
  *
@@ -54,27 +56,71 @@ module.exports.downloadFile = async function (
  */
 module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
   const filepathDir = path.resolve(path.dirname(filepath));
-  let untarCommand = `tar -x -f ${filepath}`;
+  const tempDir = path.join(filepathDir, "temp_unzip");
+  const outputDir = path.resolve(options.outputDirectoryPath || filepathDir);
 
-  if (options.outputDirectoryPath) {
-    untarCommand += ` -C ${options.outputDirectoryPath}`;
-  }
+  try {
+    // Create temp directory
+    await fs.promises.mkdir(tempDir, { recursive: true });
 
-  if (process.platform === "linux") {
-    untarCommand += " --wildcards";
-  }
+    let untarCommand = `tar -x -f ${filepath} -C ${tempDir} --exclude .github`;
+    console.log("Running command:", untarCommand);
 
-  const sourcePath = getTemplatePath(options.sourcePath || "");
+    await execAsync(untarCommand, { cwd: filepathDir });
 
-  const includePattern = `*/${sourcePath.join("/")}`;
+    // Checks if files were extracted from tar
+    const extractedFiles = await fs.promises.readdir(tempDir);
 
-  const pathDepth = sourcePath.length + 1;
-  untarCommand += ` --exclude .github --strip=${pathDepth} ${includePattern}`;
-
-  child_process.exec(untarCommand, { cwd: filepathDir }, (err, stdout, stderr) => {
-    if (err) {
-      return callback(err, stderr);
+    if (extractedFiles.length === 0) {
+      throw new Error(`No files were extracted. Please check the tarball.`);
     }
-    return callback(null, stdout);
-  });
+
+    // Assume the first item in the extracted files is the top-level directory
+    const topLevelDir = extractedFiles[0];
+
+    // Create full path to the directory and files that need to be moved
+    const dynamicSourcePath = options.sourcePath || "";
+    const sourcePath = path.join(topLevelDir, dynamicSourcePath);
+
+    // Get source path from temp directory and checks if exists
+    const sourcePathInTemp = path.join(tempDir, sourcePath);
+    const sourceExists = await fs.promises
+      .access(sourcePathInTemp)
+      .then(() => true)
+      .catch(() => false);
+    if (!sourceExists) {
+      throw new Error(
+        `The specified source path ${sourcePathInTemp} does not exist in the extracted archive.`,
+      );
+    }
+
+    await fs.promises.mkdir(outputDir, { recursive: true });
+    await moveDirectoryContents(sourcePathInTemp, outputDir);
+
+    // Clean up temp directory
+    await fs.promises.rmdir(tempDir, { recursive: true });
+
+    callback(null);
+  } catch (err) {
+    callback(err, `Error during unzip and move: ${err.message}`);
+  }
 };
+
+async function moveDirectoryContents(srcDir, destDir) {
+  // Ensure the destination directory exists
+  await fs.promises.mkdir(destDir, { recursive: true });
+
+  // Move each file or directory
+  const items = await fs.promises.readdir(srcDir, { withFileTypes: true });
+  for (const item of items) {
+    const srcItemPath = path.join(srcDir, item.name);
+    const destItemPath = path.join(destDir, item.name);
+
+    if (item.isDirectory()) {
+      await fs.promises.mkdir(destItemPath, { recursive: true });
+      await moveDirectoryContents(srcItemPath, destItemPath);
+    } else {
+      await fs.promises.rename(srcItemPath, destItemPath);
+    }
+  }
+}

--- a/lib/download.js
+++ b/lib/download.js
@@ -61,7 +61,6 @@ module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
 
   try {
     // Create temp directory
-    // await fs.promises.mkdir(tempDir, { recursive: true });
     const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "temp-unzip-"));
 
     let untarCommand = `tar -x -f ${filepath} -C ${tempDir} --exclude .github`;
@@ -120,7 +119,8 @@ async function moveDirectoryContents(srcDir, destDir) {
       await fs.promises.mkdir(destItemPath, { recursive: true });
       await moveDirectoryContents(srcItemPath, destItemPath);
     } else {
-      await fs.promises.rename(srcItemPath, destItemPath);
+      await fs.promises.copyFile(srcItemPath, destItemPath);
+      await fs.promises.unlink(srcItemPath);
     }
   }
 }

--- a/lib/download.js
+++ b/lib/download.js
@@ -66,9 +66,9 @@ module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
 
   const sourcePath = getTemplatePath(options.sourcePath || "");
 
-  const includePattern = `*/${sourcePath.join("/")}`;
+  const includePattern = path.join("*", sourcePath.join(path.sep));
 
-  const pathDepth = sourcePath.length + 1;
+  const pathDepth = includePattern.split(path.sep).length;
   untarCommand += ` --exclude .github --strip=${pathDepth} ${includePattern}`;
 
   child_process.exec(untarCommand, { cwd: filepathDir }, (err, stdout, stderr) => {

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const https = require("https");
 const path = require("path");
+const os = require("os");
 const { exec } = require("child_process");
 const { promisify } = require("util");
 
@@ -56,15 +57,14 @@ module.exports.downloadFile = async function (
  */
 module.exports.unzip = async (filepath, options = {}, callback = () => {}) => {
   const filepathDir = path.resolve(path.dirname(filepath));
-  const tempDir = path.join(filepathDir, "temp_unzip");
   const outputDir = path.resolve(options.outputDirectoryPath || filepathDir);
 
   try {
     // Create temp directory
-    await fs.promises.mkdir(tempDir, { recursive: true });
+    // await fs.promises.mkdir(tempDir, { recursive: true });
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "temp-unzip-"));
 
     let untarCommand = `tar -x -f ${filepath} -C ${tempDir} --exclude .github`;
-    console.log("Running command:", untarCommand);
 
     await execAsync(untarCommand, { cwd: filepathDir });
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,7 +1,6 @@
 const path = require("path");
 
 module.exports.getTemplatePath = (directoryPath) => {
-  directoryPath = path.normalize(directoryPath);
   const parts = directoryPath.split(path.sep);
   let [directory, target] = parts;
   if (

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,6 +1,7 @@
 const path = require("path");
 
 module.exports.getTemplatePath = (directoryPath) => {
+  directoryPath = path.normalize(directoryPath);
   const parts = directoryPath.split(path.sep);
   let [directory, target] = parts;
   if (


### PR DESCRIPTION
## Issue: 

[RADFISH-253](https://apps-st.fisheries.noaa.gov/jira/browse/RADFISH-253?workflowName=Software+Simplified+Workflow+for+Project+RADFISH&stepId=6)

Ran `npx create-radfish-app my-app` in Windows 10 in my VM and had the following error: 
```
/ Setting up applicationError: Command failed: tar -x -f C:\Users\JSUDOK~1\AppData\Local\Temp\radfish-Zu8uBs\843ea9c25a6f31afcc9e33e40d11d90849915f5b6867a2b3f179676510654814.tar.gz -C C:\Users\jsudokrew\Documents\cli\my-app --exclude .github --strip=3 *\templates\react-javascript
tar: *\templates\react-javascript: Not found in archive
tar: Error exit delayed from previous errors.

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
    at Process.callbackTrampoline (node:internal/async_hooks:130:17) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'tar -x -f C:\\Users\\JSUDOK~1\\AppData\\Local\\Temp\\radfish-Zu8uBs\\843ea9c25a6f31afcc9e33e40d11d90849915f5b6867a2b3f179676510654814.tar.gz -C C:\\Users\\jsudokrew\\Documents\\cli\\my-app --exclude .github --strip=3 *\\templates\\react-javascript'
}
Error cloning repository: Command failed: tar -x -f C:\Users\JSUDOK~1\AppData\Local\Temp\radfish-Zu8uBs\843ea9c25a6f31afcc9e33e40d11d90849915f5b6867a2b3f179676510654814.tar.gz -C C:\Users\jsudokrew\Documents\cli\my-app --exclude .github --strip=3 *\templates\react-javascript
tar: *\templates\react-javascript: Not found in archive
tar: Error exit delayed from previous errors.
```
This is the same error that was reported from a [Windows user](https://sudokrew.slack.com/archives/C05V45PUCJZ/p1719599559179159)

## Changes:

- `includePattern` used `path.join` which introduced platform-specific path separators (`\` on Windows and `/` on Unix systems) which resulted to `*\templates\react-javascript` in Windows
  - Changed to using forward slashes resulting in `*/templates/react-javascript`
- Changed `pathDepth`since it was using `includePattern` to split
- Used `matrix.os` in GitHub Actions to test on `ubuntu-latest` and `windows-latest`
- When running `npm run test` in Windows, I get the following error from `it should download a file` unit test :
  - ``` 
    Expected: StringMatching /download\path/
    Received: "C:\\Users\\jsudokrew\\Documents\\cli\\download\\path
  - Used `path.join` dynamically constructs the path using the appropriate separator for the current platform:
    - On Windows, this results in `download\\path`
    - On macOS/Linux, it results in `download/path`
  - The expectedPath is converted into a regular expression that matches the end of any path string.
    - The replace`(/\\/g, '\\\\')` part ensures that any backslashes in the expected path (which are used on Windows) are correctly escaped in the regular expression.
    - The $ at the end of the regular expression ensures that the match occurs at the end of the string.
  - Use `path.normalize` to fix mixed separators

 